### PR TITLE
add installation directives

### DIFF
--- a/core/iwasm/products/linux/CMakeLists.txt
+++ b/core/iwasm/products/linux/CMakeLists.txt
@@ -75,6 +75,8 @@ add_library (vmlib
 
 add_executable (iwasm main.c ext-lib-export.c)
 
+install (TARGETS iwasm DESTINATION bin)
+
 target_link_libraries (iwasm vmlib -lm -ldl -lpthread)
 
 add_library (libiwasm SHARED
@@ -85,6 +87,8 @@ add_library (libiwasm SHARED
              ${WASM_LIBC_SOURCE}
              ${PLATFORM_SHARED_SOURCE}
              ${MEM_ALLOC_SHARED_SOURCE})
+
+install (TARGETS libiwasm DESTINATION lib)
 
 set_target_properties (libiwasm PROPERTIES OUTPUT_NAME iwasm)
 


### PR DESCRIPTION
Allows the use of `make install` instead of manually copying the files to the right locations