### PR TITLE
Add Fedora dependency installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,13 @@ Linux
 First of all please install library dependencies of lib gcc.
 Use installation commands below for Ubuntu Linux:
 ``` Bash
-sudo apt install lib32gcc-5-dev
-sudo apt-get install g++-multilib
+sudo apt install lib32gcc-5-dev g++-multilib
 ```
+Or in Fedora:
+``` Bash
+sudo dnf install glibc-devel.i686 
+```
+
 After installing dependencies, build the source code:
 ``` Bash
 cd core/iwasm/products/linux/


### PR DESCRIPTION
This is the alternate dependency installation I had to do to get `iwasm` to compile on my Fedora machine. Also, I collapsed the Ubuntu steps into one line for conciseness.