### PR TITLE
Updates that let a restricted version of the interpreter run in SGX

### DIFF
--- a/core/iwasm/lib/native/base/base_lib_export.c
+++ b/core/iwasm/lib/native/base/base_lib_export.c
@@ -19,15 +19,13 @@
 #include <string.h>
 #include "lib_export.h"
 
-#ifdef WASM_ENABLE_BASE_LIB
+#if WASM_ENABLE_BASE_LIB
 #include "base_lib_export.h"
-#endif
 
 static NativeSymbol extended_native_symbol_defs[] = {
 /* TODO: use macro EXPORT_WASM_API() or EXPORT_WASM_API2() to
  add functions to register. */
 
-#ifdef WASM_ENABLE_BASE_LIB
         EXPORT_WASM_API(wasm_register_resource),
         EXPORT_WASM_API(wasm_response_send),
         EXPORT_WASM_API(wasm_post_request),
@@ -37,7 +35,6 @@ static NativeSymbol extended_native_symbol_defs[] = {
         EXPORT_WASM_API(wasm_timer_cancel),
         EXPORT_WASM_API(wasm_timer_restart),
         EXPORT_WASM_API(wasm_get_sys_tick_ms),
-#endif
     };
 
 int get_base_lib_export_apis(NativeSymbol **p_base_lib_apis)
@@ -46,3 +43,4 @@ int get_base_lib_export_apis(NativeSymbol **p_base_lib_apis)
     return sizeof(extended_native_symbol_defs) / sizeof(NativeSymbol);
 }
 
+#endif

--- a/core/iwasm/products/linux-sgx/CMakeLists.txt
+++ b/core/iwasm/products/linux-sgx/CMakeLists.txt
@@ -1,0 +1,89 @@
+# Copyright (C) 2019 Intel Corporation.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required (VERSION 2.8)
+
+project (iwasm)
+
+set (PLATFORM "linux-sgx")
+
+# Reset default linker flags
+set (CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")
+set (CMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS "")
+
+add_definitions(-DUSE_SGX=1)
+add_definitions(-DOPS_INPUT_OUTPUT=0)
+add_definitions(-DOPS_UNSAFE_BUFFERS=0)
+add_definitions(-DWASM_ENABLE_LOG=0)
+add_definitions(-DWASM_ENABLE_BASE_LIB=0)
+add_definitions(-DBEIHAI_ENABLE_LOG=0)
+
+# Enable repl mode if want to test spec cases
+# add_definitions(-DWASM_ENABLE_REPL)
+
+if (NOT ("$ENV{VALGRIND}" STREQUAL "YES"))
+  add_definitions(-DNVALGRIND)
+endif ()
+
+# Currently build as 64-bit by default.
+set (BUILD_AS_64BIT_SUPPORT "YES")
+
+if (CMAKE_SIZEOF_VOID_P EQUAL 8)
+if (${BUILD_AS_64BIT_SUPPORT} STREQUAL "YES")
+  # Add -fPIC flag if build as 64-bit
+  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
+  set (CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "${CMAKE_SHARED_LIBRARY_LINK_C_FLAGS} -fPIC")
+else ()
+  add_definitions (-m32)
+  set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -m32")
+  set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -m32")
+endif ()
+endif ()
+
+if (NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release)
+endif (NOT CMAKE_BUILD_TYPE)
+message ("CMAKE_BUILD_TYPE = " ${CMAKE_BUILD_TYPE})
+
+set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--gc-sections")
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ffunction-sections -fdata-sections -Wall -Wno-unused-parameter -Wno-pedantic")
+
+set (SHARED_LIB_DIR ../../../shared-lib)
+
+include_directories (.
+                     ../../runtime/include
+                     ../../runtime/platform/include
+                     ${SHARED_LIB_DIR}/include
+                     $ENV{SGX_SDK}/include)
+
+enable_language (ASM)
+
+include (../../runtime/platform/${PLATFORM}/platform.cmake)
+include (../../runtime/utils/utils.cmake)
+include (../../runtime/vmcore-wasm/vmcore.cmake)
+include (../../lib/native/libc/wasm_libc.cmake)
+include (${SHARED_LIB_DIR}/platform/${PLATFORM}/shared_platform.cmake)
+include (${SHARED_LIB_DIR}/mem-alloc/mem_alloc.cmake)
+
+#add_executable (iwasm main.c ext_lib_export.c)
+
+
+add_library (vmlib
+             ext_lib_export.c
+             ${WASM_PLATFORM_LIB_SOURCE}
+             ${WASM_UTILS_LIB_SOURCE}
+             ${VMCORE_LIB_SOURCE}
+             ${WASM_LIBC_SOURCE}
+             ${PLATFORM_SHARED_SOURCE}
+             ${MEM_ALLOC_SHARED_SOURCE})

--- a/core/iwasm/products/linux-sgx/ext_lib_export.c
+++ b/core/iwasm/products/linux-sgx/ext_lib_export.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2019 Intel Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "lib_export.h"
+
+static NativeSymbol extended_native_symbol_defs[] = { };
+
+#include "ext_lib_export.h"

--- a/core/iwasm/products/linux/CMakeLists.txt
+++ b/core/iwasm/products/linux/CMakeLists.txt
@@ -29,6 +29,9 @@ if (NOT ("$ENV{VALGRIND}" STREQUAL "YES"))
   add_definitions(-DNVALGRIND)
 endif ()
 
+add_definitions(-DOPS_INPUT_OUTPUT=1)
+add_definitions(-DOPS_UNSAFE_BUFFERS=1)
+
 # Currently build as 64-bit by default.
 set (BUILD_AS_64BIT_SUPPORT "YES")
 
@@ -98,4 +101,3 @@ install (TARGETS libiwasm DESTINATION lib)
 set_target_properties (libiwasm PROPERTIES OUTPUT_NAME iwasm)
 
 target_link_libraries (libiwasm -lm -ldl -lpthread)
-

--- a/core/iwasm/runtime/include/wasm_log.h
+++ b/core/iwasm/runtime/include/wasm_log.h
@@ -46,6 +46,7 @@ extern "C" {
  * The wasm_log and macros LOG_ERROR etc. can be used to output log messages
  * by one log calling.
  */
+#if WASM_ENABLE_LOG != 0
 int  _wasm_log_init (void);
 void _wasm_log_set_verbose_level (int level);
 bool _wasm_log_begin (int level);
@@ -55,7 +56,6 @@ void _wasm_log_end (void);
 void _wasm_log (int level, const char *file, int line,
                 const char *fmt, ...);
 
-#if WASM_ENABLE_LOG != 0
 # define wasm_log_init()               _wasm_log_init ()
 # define wasm_log_set_verbose_level(l) _wasm_log_set_verbose_level (l)
 # define wasm_log_begin(l)             _wasm_log_begin (l)

--- a/core/iwasm/runtime/platform/include/wasm_platform_log.h
+++ b/core/iwasm/runtime/platform/include/wasm_platform_log.h
@@ -17,7 +17,9 @@
 #ifndef _WASM_PLATFORM_LOG
 #define _WASM_PLATFORM_LOG
 
-#define wasm_printf printf
+#include "bh_platform.h"
+
+#define wasm_printf bh_printf
 
 #define wasm_vprintf vprintf
 

--- a/core/iwasm/runtime/platform/linux-sgx/platform.cmake
+++ b/core/iwasm/runtime/platform/linux-sgx/platform.cmake
@@ -1,0 +1,25 @@
+# Copyright (C) 2019 Intel Corporation.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_definitions (-D__POSIX__ -D_XOPEN_SOURCE=600 -D_POSIX_C_SOURCE=199309L)
+
+set (PLATFORM_LIB_DIR ${CMAKE_CURRENT_LIST_DIR})
+
+include_directories(${PLATFORM_LIB_DIR})
+include_directories(${PLATFORM_LIB_DIR}/../include)
+
+file (GLOB_RECURSE source_all ${PLATFORM_LIB_DIR}/*.c)
+
+set (WASM_PLATFORM_LIB_SOURCE ${source_all})
+

--- a/core/iwasm/runtime/platform/linux-sgx/wasm_native.c
+++ b/core/iwasm/runtime/platform/linux-sgx/wasm_native.c
@@ -61,7 +61,7 @@ __syscall0_wrapper(int32 arg0)
         case 199: /* getuid */
             /* TODO */
         default:
-            printf("##_syscall0 called, syscall id: %d\n", arg0);
+            bh_printf("##_syscall0 called, syscall id: %d\n", arg0);
     }
     return 0;
 }
@@ -73,7 +73,7 @@ __syscall1_wrapper(int32 arg0, int32 arg1)
         case 6: /* close */
             /* TODO */
         default:
-            printf("##_syscall1 called, syscall id: %d\n", arg0);
+            bh_printf("##_syscall1 called, syscall id: %d\n", arg0);
     }
     return 0;
 }
@@ -85,7 +85,7 @@ __syscall2_wrapper(int32 arg0, int32 arg1, int32 arg2)
         case 183: /* getcwd */
             /* TODO */
         default:
-            printf("##_syscall2 called, syscall id: %d\n", arg0);
+            bh_printf("##_syscall2 called, syscall id: %d\n", arg0);
     }
     return 0;
 }
@@ -139,7 +139,7 @@ __syscall3_wrapper(int32 arg0, int32 arg1, int32 arg2, int32 arg3)
         case 221: /* fcntl */
         /* TODO */
         default:
-        printf("##_syscall3 called, syscall id: %d\n", arg0);
+            bh_printf("##_syscall3 called, syscall id: %d\n", arg0);
     }
     return 0;
 }
@@ -148,7 +148,7 @@ static int32
 __syscall4_wrapper(int32 arg0, int32 arg1, int32 arg2,
                    int32 arg3, int32 arg4)
 {
-    printf("##_syscall4 called, syscall id: %d\n", arg0);
+    bh_printf("##_syscall4 called, syscall id: %d\n", arg0);
     return 0;
 }
 
@@ -160,7 +160,7 @@ __syscall5_wrapper(int32 arg0, int32 arg1, int32 arg2,
         case 140: /* llseek */
             /* TODO */
         default:
-            printf("##_syscall5 called, args[0]: %d\n", arg0);
+            bh_printf("##_syscall5 called, args[0]: %d\n", arg0);
     }
     return 0;
 }

--- a/core/iwasm/runtime/platform/linux-sgx/wasm_native.c
+++ b/core/iwasm/runtime/platform/linux-sgx/wasm_native.c
@@ -1,0 +1,332 @@
+/*
+ * Copyright (C) 2019 Intel Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE /* for O_DIRECT */
+#endif
+
+#include "wasm_native.h"
+#include "wasm_runtime.h"
+#include "wasm_log.h"
+#include "wasm_memory.h"
+#include "wasm_platform_log.h"
+
+#include <sys/ioctl.h>
+#include <sys/uio.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <pwd.h>
+#include <fcntl.h>
+#include <errno.h>
+
+
+#define get_module_inst() \
+    wasm_runtime_get_current_module_inst()
+
+#define validate_app_addr(offset, size) \
+    wasm_runtime_validate_app_addr(module_inst, offset, size)
+
+#define addr_app_to_native(offset) \
+    wasm_runtime_addr_app_to_native(module_inst, offset)
+
+#define addr_native_to_app(ptr) \
+    wasm_runtime_addr_native_to_app(module_inst, ptr)
+
+#define module_malloc(size) \
+    wasm_runtime_module_malloc(module_inst, size)
+
+#define module_free(offset) \
+    wasm_runtime_module_free(module_inst, offset)
+
+
+static int32
+__syscall0_wrapper(int32 arg0)
+{
+    switch (arg0) {
+        case 199: /* getuid */
+            /* TODO */
+        default:
+            printf("##_syscall0 called, syscall id: %d\n", arg0);
+    }
+    return 0;
+}
+
+static int32
+__syscall1_wrapper(int32 arg0, int32 arg1)
+{
+    switch (arg0) {
+        case 6: /* close */
+            /* TODO */
+        default:
+            printf("##_syscall1 called, syscall id: %d\n", arg0);
+    }
+    return 0;
+}
+
+static int32
+__syscall2_wrapper(int32 arg0, int32 arg1, int32 arg2)
+{
+    switch (arg0) {
+        case 183: /* getcwd */
+            /* TODO */
+        default:
+            printf("##_syscall2 called, syscall id: %d\n", arg0);
+    }
+    return 0;
+}
+
+static int32
+__syscall3_wrapper(int32 arg0, int32 arg1, int32 arg2, int32 arg3)
+{
+    WASMModuleInstance *module_inst = get_module_inst();
+
+    switch (arg0) {
+        case 146: /* writev */
+        {
+            /* Implement syscall 54 and syscall 146 to support printf()
+               for non SIDE_MODULE=1 mode */
+            struct iovec_app {
+                int32 iov_base_offset;
+                uint32 iov_len;
+            } *vec;
+            int32 vec_offset = arg2, str_offset;
+            uint32 iov_count = arg3, i;
+            int32 count = 0;
+            char *iov_base, *str;
+
+            if (!validate_app_addr(vec_offset, sizeof(struct iovec_app)))
+                return 0;
+
+            vec = (struct iovec_app *)addr_app_to_native(vec_offset);
+            for (i = 0; i < iov_count; i++, vec++) {
+                if (vec->iov_len > 0) {
+                    if (!validate_app_addr(vec->iov_base_offset, 1))
+                        return 0;
+                    iov_base = (char*)addr_app_to_native(vec->iov_base_offset);
+
+                    if (!(str_offset = module_malloc(vec->iov_len + 1)))
+                        return 0;
+
+                    str = addr_app_to_native(str_offset);
+
+                    memcpy(str, iov_base, vec->iov_len);
+                    str[vec->iov_len] = '\0';
+                    count += wasm_printf("%s", str);
+
+                    module_free(str_offset);
+                }
+            }
+            return count;
+        }
+        case 145: /* readv */
+        case 3: /* read*/
+        case 5: /* open */
+        case 221: /* fcntl */
+        /* TODO */
+        default:
+        printf("##_syscall3 called, syscall id: %d\n", arg0);
+    }
+    return 0;
+}
+
+static int32
+__syscall4_wrapper(int32 arg0, int32 arg1, int32 arg2,
+                   int32 arg3, int32 arg4)
+{
+    printf("##_syscall4 called, syscall id: %d\n", arg0);
+    return 0;
+}
+
+static int32
+__syscall5_wrapper(int32 arg0, int32 arg1, int32 arg2,
+                   int32 arg3, int32 arg4, int32 arg5)
+{
+    switch (arg0) {
+        case 140: /* llseek */
+            /* TODO */
+        default:
+            printf("##_syscall5 called, args[0]: %d\n", arg0);
+    }
+    return 0;
+}
+
+#define GET_EMCC_SYSCALL_ARGS()                                     \
+  WASMModuleInstance *module_inst = get_module_inst();              \
+  int32 *args;                                                      \
+  if (!validate_app_addr(args_off, 1))                              \
+    return 0;                                                       \
+  args = addr_app_to_native(args_off)                               \
+
+#define EMCC_SYSCALL_WRAPPER0(id)                                   \
+  static int32 ___syscall##id##_wrapper(int32 _id) {                \
+    return __syscall0_wrapper(id);                                  \
+  }
+
+#define EMCC_SYSCALL_WRAPPER1(id)                                   \
+  static int32 ___syscall##id##_wrapper(int32 _id, int32 args_off) {\
+    GET_EMCC_SYSCALL_ARGS();                                        \
+    return __syscall1_wrapper(id, args[0]);                         \
+  }
+
+#define EMCC_SYSCALL_WRAPPER2(id)                                   \
+  static int32 ___syscall##id##_wrapper(int32 _id, int32 args_off) {\
+    GET_EMCC_SYSCALL_ARGS();                                        \
+    return __syscall2_wrapper(id, args[0], args[1]);                \
+  }
+
+#define EMCC_SYSCALL_WRAPPER3(id)                                   \
+  static int32 ___syscall##id##_wrapper(int32 _id, int32 args_off) {\
+    GET_EMCC_SYSCALL_ARGS();                                        \
+    return __syscall3_wrapper(id, args[0], args[1], args[2]);       \
+  }
+
+#define EMCC_SYSCALL_WRAPPER4(id)                                   \
+  static int32 ___syscall##id##_wrapper(int32 _id, int32 args_off) {\
+    GET_EMCC_SYSCALL_ARGS();                                        \
+    return __syscall4_wrapper(id, args[0], args[1], args[2], args[3]);\
+  }
+
+#define EMCC_SYSCALL_WRAPPER5(id)                                   \
+  static int32 ___syscall##id##_wrapper(int32 _id, int32 args_off) {\
+    GET_EMCC_SYSCALL_ARGS();                                        \
+    return __syscall5_wrapper(id, args[0], args[1], args[2],        \
+                              args[3], args[4]);                    \
+  }
+
+EMCC_SYSCALL_WRAPPER0(199)
+
+EMCC_SYSCALL_WRAPPER1(6)
+
+EMCC_SYSCALL_WRAPPER2(183)
+
+EMCC_SYSCALL_WRAPPER3(3)
+EMCC_SYSCALL_WRAPPER3(5)
+EMCC_SYSCALL_WRAPPER3(54)
+EMCC_SYSCALL_WRAPPER3(145)
+EMCC_SYSCALL_WRAPPER3(146)
+EMCC_SYSCALL_WRAPPER3(221)
+
+EMCC_SYSCALL_WRAPPER5(140)
+
+static int32
+getTotalMemory_wrapper()
+{
+    WASMModuleInstance *module_inst = wasm_runtime_get_current_module_inst();
+    WASMMemoryInstance *memory = module_inst->default_memory;
+    return NumBytesPerPage * memory->cur_page_count;
+}
+
+static int32
+enlargeMemory_wrapper()
+{
+    bool ret;
+    WASMModuleInstance *module_inst = wasm_runtime_get_current_module_inst();
+    WASMMemoryInstance *memory = module_inst->default_memory;
+    uint32 DYNAMICTOP_PTR_offset = module_inst->DYNAMICTOP_PTR_offset;
+    uint32 addr_data_offset = *(uint32*)(memory->global_data + DYNAMICTOP_PTR_offset);
+    uint32 *DYNAMICTOP_PTR = (uint32*)(memory->memory_data + addr_data_offset);
+    uint32 memory_size_expected = *DYNAMICTOP_PTR;
+    uint32 total_page_count = (memory_size_expected + NumBytesPerPage - 1) / NumBytesPerPage;
+
+    if (total_page_count < memory->cur_page_count) {
+        return 1;
+    }
+    else {
+        ret = wasm_runtime_enlarge_memory(module_inst, total_page_count -
+                                          memory->cur_page_count);
+        return ret ? 1 : 0;
+    }
+}
+
+static void
+_abort_wrapper(int32 code)
+{
+    WASMModuleInstance *module_inst = wasm_runtime_get_current_module_inst();
+    char buf[32];
+
+    snprintf(buf, sizeof(buf), "env.abort(%i)", code);
+    wasm_runtime_set_exception(module_inst, buf);
+}
+
+static void
+abortOnCannotGrowMemory_wrapper()
+{
+    WASMModuleInstance *module_inst = wasm_runtime_get_current_module_inst();
+    wasm_runtime_set_exception(module_inst, "abort on cannot grow memory");
+}
+
+static void
+___setErrNo_wrapper(int32 error_no)
+{
+    errno = error_no;
+}
+
+/* TODO: add function parameter/result types check */
+#define REG_NATIVE_FUNC(module_name, func_name) \
+    {#module_name, #func_name, func_name##_wrapper}
+
+typedef struct WASMNativeFuncDef {
+    const char *module_name;
+    const char *func_name;
+    void *func_ptr;
+} WASMNativeFuncDef;
+
+static WASMNativeFuncDef native_func_defs[] = {
+    REG_NATIVE_FUNC(env, __syscall0),
+    REG_NATIVE_FUNC(env, __syscall1),
+    REG_NATIVE_FUNC(env, __syscall2),
+    REG_NATIVE_FUNC(env, __syscall3),
+    REG_NATIVE_FUNC(env, __syscall4),
+    REG_NATIVE_FUNC(env, __syscall5),
+    REG_NATIVE_FUNC(env, ___syscall3),
+    REG_NATIVE_FUNC(env, ___syscall5),
+    REG_NATIVE_FUNC(env, ___syscall6),
+    REG_NATIVE_FUNC(env, ___syscall54),
+    REG_NATIVE_FUNC(env, ___syscall140),
+    REG_NATIVE_FUNC(env, ___syscall145),
+    REG_NATIVE_FUNC(env, ___syscall146),
+    REG_NATIVE_FUNC(env, ___syscall183),
+    REG_NATIVE_FUNC(env, ___syscall199),
+    REG_NATIVE_FUNC(env, ___syscall221),
+    REG_NATIVE_FUNC(env, _abort),
+    REG_NATIVE_FUNC(env, abortOnCannotGrowMemory),
+    REG_NATIVE_FUNC(env, enlargeMemory),
+    REG_NATIVE_FUNC(env, getTotalMemory),
+    REG_NATIVE_FUNC(env, ___setErrNo),
+};
+
+void*
+wasm_platform_native_func_lookup(const char *module_name,
+                                 const char *func_name)
+{
+    uint32 size = sizeof(native_func_defs) / sizeof(WASMNativeFuncDef);
+    WASMNativeFuncDef *func_def = native_func_defs;
+    WASMNativeFuncDef *func_def_end = func_def + size;
+
+    if (!module_name || !func_name)
+        return NULL;
+
+    while (func_def < func_def_end) {
+        if (!strcmp(func_def->module_name, module_name)
+            && !strcmp(func_def->func_name, func_name))
+            return (void*)(uintptr_t)func_def->func_ptr;
+        func_def++;
+    }
+
+    return NULL;
+}

--- a/core/iwasm/runtime/utils/wasm_log.c
+++ b/core/iwasm/runtime/utils/wasm_log.c
@@ -20,6 +20,8 @@
 #include "wasm_thread.h"
 
 
+#if WASM_ENABLE_LOG != 0
+
 /**
  * The verbose level of the log system.  Only those verbose logs whose
  * levels are less than or equal to this value are outputed.
@@ -100,3 +102,5 @@ _wasm_log (int level, const char *file, int line,
     _wasm_log_end ();
   }
 }
+
+#endif  /* WASM_ENABLE_LOG */

--- a/core/shared-lib/include/bh_common.h
+++ b/core/shared-lib/include/bh_common.h
@@ -23,6 +23,9 @@
 #include "bh_log.h"
 #include "bh_list.h"
 
+typedef void (*bh_print_function_t)(const char* message);
+void bh_set_print_function(bh_print_function_t pf);
+
 #define bh_memcpy_s(dest, dlen, src, slen) do {                         \
     int _ret = slen == 0 ? 0 : b_memcpy_s (dest, dlen, src, slen);      \
     (void)_ret;                                                         \

--- a/core/shared-lib/include/bh_log.h
+++ b/core/shared-lib/include/bh_log.h
@@ -48,13 +48,13 @@ extern "C" {
  * bh_log and macros LOG_ERROR etc. can be used to output log messages
  * that can be wrapped into one log calling.
  */
+#if BEIHAI_ENABLE_LOG != 0
 int _bh_log_init(void);
 void _bh_log_set_verbose_level(int level);
 void _bh_log_printf(const char *fmt, ...);
 void _bh_log_vprintf(const char *fmt, va_list ap);
 void _bh_log_commit(void);
 
-#if BEIHAI_ENABLE_LOG != 0
 # define bh_log_init()               _bh_log_init ()
 # define bh_log_set_verbose_level(l) _bh_log_set_verbose_level (l)
 # define bh_log_printf(...)          _bh_log_printf (__VA_ARGS__)
@@ -68,12 +68,10 @@ void _bh_log_commit(void);
 # define bh_log_commit()             (void)0
 #endif  /* BEIHAI_ENABLE_LOG != 0 */
 
+#if BEIHAI_ENABLE_LOG != 0
 void _bh_log(const char *tag, const char *file, int line, const char *fmt, ...);
 
-/* Always print fatal message */
 # define LOG_FATAL(...)         _bh_log ("V0.", NULL, 0, __VA_ARGS__)
-
-#if BEIHAI_ENABLE_LOG != 0
 # define LOG_ERROR(...)         _bh_log ("V1.", NULL, 0, __VA_ARGS__)
 # define LOG_WARNING(...)       _bh_log ("V2.", NULL, 0, __VA_ARGS__)
 # define LOG_INFO_RELEASE(...)  _bh_log ("V3.", NULL, 0, __VA_ARGS__)

--- a/core/shared-lib/include/config.h
+++ b/core/shared-lib/include/config.h
@@ -26,7 +26,9 @@
 #define DEFAULT_MEM_ALLOCATOR MEM_ALLOCATOR_EMS
 
 /* Beihai log system */
+#ifndef BEIHAI_ENABLE_LOG
 #define BEIHAI_ENABLE_LOG 1
+#endif
 
 /* Beihai debugger support */
 #define BEIHAI_ENABLE_TOOL_AGENT 1
@@ -43,7 +45,9 @@
 #endif
 
 /* WASM VM log system */
+#ifndef WASM_ENABLE_LOG
 #define WASM_ENABLE_LOG 1
+#endif
 
 /* WASM Interpreter labels-as-values feature */
 #define WASM_ENABLE_LABELS_AS_VALUES 1

--- a/core/shared-lib/mem-alloc/bh_memory.c
+++ b/core/shared-lib/mem-alloc/bh_memory.c
@@ -15,9 +15,9 @@
  */
 
 #include "bh_config.h"
+#include "bh_platform.h"
 #include "bh_memory.h"
 #include "mem_alloc.h"
-#include <stdio.h>
 #include <stdlib.h>
 
 #if BEIHAI_ENABLE_MEMORY_PROFILING != 0
@@ -76,7 +76,7 @@ int bh_memory_init_with_pool(void *mem, unsigned int bytes)
         global_pool_size = bytes;
         return 0;
     }
-    printf("Init memory with pool (%p, %u) failed.\n", mem, bytes);
+    bh_printf("Init memory with pool (%p, %u) failed.\n", mem, bytes);
     return -1;
 }
 
@@ -91,7 +91,7 @@ int bh_memory_init_with_allocator(void *_malloc_func, void *_free_func)
 #endif
         return 0;
     }
-    printf("Init memory with allocator (%p, %p) failed.\n", _malloc_func,
+    bh_printf("Init memory with allocator (%p, %p) failed.\n", _malloc_func,
             _free_func);
     return -1;
 }
@@ -117,7 +117,7 @@ int bh_memory_pool_size()
 void* bh_malloc_internal(unsigned int size)
 {
     if (memory_mode == MEMORY_MODE_UNKNOWN) {
-        printf("bh_malloc failed: memory hasn't been initialize.\n");
+        bh_printf("bh_malloc failed: memory hasn't been initialize.\n");
         return NULL;
     } else if (memory_mode == MEMORY_MODE_POOL) {
         return mem_allocator_malloc(pool_allocator, size);
@@ -129,7 +129,7 @@ void* bh_malloc_internal(unsigned int size)
 void bh_free_internal(void *ptr)
 {
     if (memory_mode == MEMORY_MODE_UNKNOWN) {
-        printf("bh_free failed: memory hasn't been initialize.\n");
+        bh_printf("bh_free failed: memory hasn't been initialize.\n");
     } else if (memory_mode == MEMORY_MODE_POOL) {
         mem_allocator_free(pool_allocator, ptr);
     } else {
@@ -250,7 +250,7 @@ void memory_usage_summarize()
 
     profile = memory_profiles_list;
     while (profile) {
-        printf("malloc:%d:malloc_num:%d:free:%d:free_num:%d:%s\n",
+        bh_printf("malloc:%d:malloc_num:%d:free:%d:free_num:%d:%s\n",
             profile->total_malloc,
             profile->malloc_num,
             profile->total_free,
@@ -267,7 +267,7 @@ void memory_profile_print(const char *file,
                           const char *func,
                           int alloc)
 {
-    printf("location:%s@%d:used:%d:contribution:%d\n",
+    bh_printf("location:%s@%d:used:%d:contribution:%d\n",
            func, line, memory_in_use, alloc);
 }
 
@@ -328,4 +328,3 @@ void bh_free_profile(const char *file, int line, const char *func, void *ptr)
 }
 #endif /* end of BEIHAI_ENABLE_MEMORY_PROFILING */
 #endif /* end of MALLOC_MEMORY_FROM_SYSTEM*/
-

--- a/core/shared-lib/mem-alloc/ems/ems_alloc.c
+++ b/core/shared-lib/mem-alloc/ems/ems_alloc.c
@@ -118,7 +118,7 @@ static void unlink_hmu(gc_heap_t *heap, hmu_t *hmu)
         }
 
         if (!node) {
-            printf("[GC_ERROR]couldn't find the node in the normal list");
+            bh_printf("[GC_ERROR]couldn't find the node in the normal list");
         }
     } else {
         remove_tree_node((hmu_tree_node_t *) hmu);
@@ -392,7 +392,7 @@ gc_object_t _gc_alloc_vo_i_heap(void *vheap,
     ret = hmu_to_obj(hmu);
 
 #if BH_ENABLE_MEMORY_PROFILING != 0
-    printf("HEAP.ALLOC: heap: %p, size: %u", heap, size);
+    bh_printf("HEAP.ALLOC: heap: %p, size: %u", heap, size);
 #endif
 
     FINISH:
@@ -434,7 +434,7 @@ gc_object_t _gc_alloc_jo_i_heap(void *vheap,
     ret = hmu_to_obj(hmu);
 
 #if BH_ENABLE_MEMORY_PROFILING != 0
-    printf("HEAP.ALLOC: heap: %p, size: %u", heap, size);
+    bh_printf("HEAP.ALLOC: heap: %p, size: %u", heap, size);
 #endif
 
     FINISH:
@@ -495,7 +495,7 @@ int gc_free_i_heap(void *vheap, gc_object_t obj ALLOC_EXTRA_PARAMETERS)
             heap->total_free_size += size;
 #endif
 #if BH_ENABLE_MEMORY_PROFILING != 0
-            printf("HEAP.FREE, heap: %p, size: %u\n",heap, size);
+            bh_printf("HEAP.FREE, heap: %p, size: %u\n",heap, size);
 #endif
 
             if (!hmu_get_pinuse(hmu)) {
@@ -538,12 +538,12 @@ int gc_free_i_heap(void *vheap, gc_object_t obj ALLOC_EXTRA_PARAMETERS)
 
 void gc_dump_heap_stats(gc_heap_t *heap)
 {
-    printf("heap: %p, heap start: %p\n", heap, heap->base_addr);
-    printf(
+    bh_printf("heap: %p, heap start: %p\n", heap, heap->base_addr);
+    bh_printf(
             "total malloc: totalfree: %u, current: %u, highmark: %u, gc cnt: %u\n",
             heap->total_free_size, heap->current_size, heap->highmark_size,
             heap->total_gc_count);
-    printf("g_total_malloc=%lu, g_total_free=%lu, occupied=%lu\n",
+    bh_printf("g_total_malloc=%lu, g_total_free=%lu, occupied=%lu\n",
             g_total_malloc, g_total_free, g_total_malloc - g_total_free);
 }
 

--- a/core/shared-lib/mem-alloc/ems/ems_gc_internal.h
+++ b/core/shared-lib/mem-alloc/ems/ems_gc_internal.h
@@ -21,6 +21,7 @@
 extern "C" {
 #endif
 
+#include "bh_platform.h"
 #include "bh_thread.h"
 #include "bh_memory.h"
 #include "bh_assert.h"
@@ -279,4 +280,3 @@ extern int (*gct_vm_gc_finished)(void);
 #endif
 
 #endif
-

--- a/core/shared-lib/mem-alloc/ems/ems_kfc.c
+++ b/core/shared-lib/mem-alloc/ems/ems_kfc.c
@@ -30,7 +30,7 @@ int gci_check_platform()
 {
 #define CHECK(x, y)  do {                                       \
   if((x) != (y)) {                                              \
-    printf("Platform checking failed on LINE %d at FILE %s.",   \
+    bh_printf("Platform checking failed on LINE %d at FILE %s.",   \
            __LINE__, __FILE__);                                 \
     return GC_ERROR;                                            \
   }                                                             \
@@ -62,12 +62,12 @@ gc_handle_t gc_init_with_pool(char *buf, gc_size_t buf_size)
 
     /* check system compatibility*/
     if (gci_check_platform() == GC_ERROR) {
-        printf("Check platform compatibility failed");
+        bh_printf("Check platform compatibility failed");
         return NULL;
     }
 
     if (buf_size < 1024) {
-        printf("[GC_ERROR]heap_init_size(%d) < 1024", buf_size);
+        bh_printf("[GC_ERROR]heap_init_size(%d) < 1024", buf_size);
         return NULL;
     }
 
@@ -79,12 +79,12 @@ gc_handle_t gc_init_with_pool(char *buf, gc_size_t buf_size)
 
     ret = gct_vm_mutex_init(&heap->lock);
     if (ret != BHT_OK) {
-        printf("[GC_ERROR]failed to init lock ");
+        bh_printf("[GC_ERROR]failed to init lock ");
         return NULL;
     }
 
 #ifdef BH_FOOTPRINT
-    printf("\nINIT HEAP 0x%08x %d\n", base_addr, heap_max_size);
+    bh_printf("\nINIT HEAP 0x%08x %d\n", base_addr, heap_max_size);
 #endif
 
     /* init all data structures*/
@@ -131,7 +131,7 @@ gc_handle_t gc_init_with_pool(char *buf, gc_size_t buf_size)
                     && HMU_FC_NORMAL_MAX_SIZE < q->size); /*@NOTIFY*/
 
 #if BH_ENABLE_MEMORY_PROFILING != 0
-    printf("heap is successfully initialized with max_size=%u.",
+    bh_printf("heap is successfully initialized with max_size=%u.",
             heap_max_size);
 #endif
     return heap;

--- a/core/shared-lib/platform/linux-sgx/bh_assert.c
+++ b/core/shared-lib/platform/linux-sgx/bh_assert.c
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2019 Intel Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bh_platform.h"
+#include "bh_assert.h"
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifdef BH_TEST
+#include <setjmp.h>
+#endif
+
+#ifdef BH_TEST
+/* for exception throwing */
+jmp_buf bh_test_jb;
+#endif
+
+void bh_assert_internal(int v, const char *file_name, int line_number,
+        const char *expr_string)
+{
+    if (v)
+        return;
+
+    if (!file_name)
+        file_name = "NULL FILENAME";
+    if (!expr_string)
+        expr_string = "NULL EXPR_STRING";
+
+    printf("\nASSERTION FAILED: %s, at FILE=%s, LINE=%d\n", expr_string,
+            file_name, line_number);
+
+#ifdef BH_TEST
+    longjmp(bh_test_jb, 1);
+#endif
+
+    abort();
+}
+
+void bh_debug_internal(const char *file_name, int line_number, const char *fmt,
+        ...)
+{
+#ifndef JEFF_TEST_VERIFIER
+    va_list args;
+
+    va_start(args, fmt);
+    bh_assert(file_name);
+
+    printf("\nDebug info FILE=%s, LINE=%d: ", file_name, line_number);
+    vprintf(fmt, args);
+
+    va_end(args);
+    printf("\n");
+#endif
+}
+

--- a/core/shared-lib/platform/linux-sgx/bh_definition.c
+++ b/core/shared-lib/platform/linux-sgx/bh_definition.c
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2019 Intel Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bh_definition.h"
+#include "bh_platform.h"
+
+int bh_return(int ret)
+{
+    return ret;
+}
+
+#define RSIZE_MAX 0x7FFFFFFF
+int b_memcpy_s(void * s1, unsigned int s1max, const void * s2, unsigned int n)
+{
+    char *dest = (char*) s1;
+    char *src = (char*) s2;
+    if (n == 0) {
+        return 0;
+    }
+
+    if (s1 == NULL || s1max > RSIZE_MAX) {
+        return -1;
+    }
+    if (s2 == NULL || n > s1max) {
+        memset(dest, 0, s1max);
+        return -1;
+    }
+    memcpy(dest, src, n);
+    return 0;
+}
+
+int b_strcat_s(char * s1, size_t s1max, const char * s2)
+{
+    if (NULL
+            == s1|| NULL == s2 || s1max < (strlen(s1) + strlen(s2) + 1) || s1max > RSIZE_MAX) {
+        return -1;
+    }
+
+    strcat(s1, s2);
+
+    return 0;
+}
+
+int b_strcpy_s(char * s1, size_t s1max, const char * s2)
+{
+    if (NULL
+            == s1|| NULL == s2 || s1max < (strlen(s2) + 1) || s1max > RSIZE_MAX) {
+        return -1;
+    }
+
+    strncpy(s1, s2, s1max);
+
+    return 0;
+}
+
+int fopen_s(FILE ** pFile, const char *filename, const char *mode)
+{
+    if (NULL == pFile || NULL == filename || NULL == mode) {
+        return -1;
+    }
+
+    *pFile = fopen(filename, mode);
+
+    if (NULL == *pFile)
+        return -1;
+
+    return 0;
+}

--- a/core/shared-lib/platform/linux-sgx/bh_platform.c
+++ b/core/shared-lib/platform/linux-sgx/bh_platform.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2019 Intel Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bh_platform.h"
+
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#define FIXED_BUFFER_SIZE (1<<14)
+static bh_print_function_t print_function = NULL;
+
+char *bh_strdup(const char *s)
+{
+    char *s1 = NULL;
+    if (s && (s1 = bh_malloc(strlen(s) + 1)))
+        memcpy(s1, s, strlen(s) + 1);
+    return s1;
+}
+
+int bh_platform_init()
+{
+    return 0;
+}
+
+int putchar(int c)
+{
+    return 0;
+}
+
+int puts(const char *s)
+{
+    return 0;
+}
+
+void bh_set_print_function(bh_print_function_t pf)
+{
+    print_function = pf;
+}
+
+int printf(const char *message, ...)
+{
+    if (print_function != NULL) {
+        char msg[FIXED_BUFFER_SIZE] = { '\0' };
+        va_list ap;
+        va_start(ap, message);
+        vsnprintf(msg, FIXED_BUFFER_SIZE, message, ap);
+        va_end(ap);
+        print_function(msg);
+    }
+
+    return 0;
+}
+
+int __printf_chk(int flag, const char * format, ...)
+{
+    return 0;
+}

--- a/core/shared-lib/platform/linux-sgx/bh_platform.c
+++ b/core/shared-lib/platform/linux-sgx/bh_platform.c
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "bh_common.h"
 #include "bh_platform.h"
 
 #include <sys/stat.h>
@@ -51,7 +52,7 @@ void bh_set_print_function(bh_print_function_t pf)
     print_function = pf;
 }
 
-int printf(const char *message, ...)
+int bh_printf(const char *message, ...)
 {
     if (print_function != NULL) {
         char msg[FIXED_BUFFER_SIZE] = { '\0' };
@@ -62,10 +63,5 @@ int printf(const char *message, ...)
         print_function(msg);
     }
 
-    return 0;
-}
-
-int __printf_chk(int flag, const char * format, ...)
-{
     return 0;
 }

--- a/core/shared-lib/platform/linux-sgx/bh_platform.h
+++ b/core/shared-lib/platform/linux-sgx/bh_platform.h
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2019 Intel Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _BH_PLATFORM_H
+#define _BH_PLATFORM_H
+
+#include "bh_config.h"
+#include "bh_types.h"
+#include "bh_memory.h"
+#include <inttypes.h>
+#include <stdbool.h>
+#include <assert.h>
+#include <time.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include <stdarg.h>
+#include <ctype.h>
+#include <pthread.h>
+#include <limits.h>
+#include <semaphore.h>
+#include <errno.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef uint64_t uint64;
+typedef int64_t int64;
+
+extern void DEBUGME(void);
+
+#define DIE do{bh_debug("Die here\n\n\n\n\n\n\n\n\n\n\n\n\n\n"); DEBUGME(void); while(1);}while(0)
+
+#define BH_PLATFORM "Linux"
+
+/* NEED qsort */
+
+#define _STACK_SIZE_ADJUSTMENT (32 * 1024)
+
+/* Stack size of applet threads's native part.  */
+#define BH_APPLET_PRESERVED_STACK_SIZE      (8 * 1024 + _STACK_SIZE_ADJUSTMENT)
+
+/* Default thread priority */
+#define BH_THREAD_DEFAULT_PRIORITY 0
+
+#define BH_ROUTINE_MODIFIER
+
+#define BHT_TIMEDOUT ETIMEDOUT
+
+#define INVALID_THREAD_ID 0xFFffFFff
+
+typedef pthread_t korp_tid;
+typedef pthread_mutex_t korp_mutex;
+typedef sem_t korp_sem;
+typedef pthread_cond_t korp_cond;
+typedef pthread_t korp_thread;
+typedef void* (*thread_start_routine_t)(void*);
+
+#define wa_malloc bh_malloc
+#define wa_free bh_free
+#define wa_strdup bh_strdup
+
+int snprintf(char *buffer, size_t count, const char *format, ...);
+double fmod(double x, double y);
+float fmodf(float x, float y);
+double sqrt(double x);
+
+#define BH_WAIT_FOREVER 0xFFFFFFFF
+
+#ifndef NULL
+#  define NULL ((void*) 0)
+#endif
+
+/**
+ * Return the offset of the given field in the given type.
+ *
+ * @param Type the type containing the filed
+ * @param field the field in the type
+ *
+ * @return the offset of field in Type
+ */
+#ifndef offsetof
+#define offsetof(Type, field) ((size_t)(&((Type *)0)->field))
+#endif
+
+#define bh_assert assert
+
+int b_memcpy_s(void * s1, unsigned int s1max, const void * s2,
+               unsigned int n);
+int b_strcat_s(char * s1, size_t s1max, const char * s2);
+int b_strcpy_s(char * s1, size_t s1max, const char * s2);
+
+char *bh_strdup(const char *s);
+
+int bh_platform_init();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/core/shared-lib/platform/linux-sgx/bh_platform.h
+++ b/core/shared-lib/platform/linux-sgx/bh_platform.h
@@ -32,23 +32,20 @@
 #include <ctype.h>
 #include <pthread.h>
 #include <limits.h>
-#include <semaphore.h>
 #include <errno.h>
-#include <sys/socket.h>
-#include <netinet/in.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+extern int bh_printf(const char *message, ...);
+
 typedef uint64_t uint64;
 typedef int64_t int64;
 
-extern void DEBUGME(void);
-
 #define DIE do{bh_debug("Die here\n\n\n\n\n\n\n\n\n\n\n\n\n\n"); DEBUGME(void); while(1);}while(0)
 
-#define BH_PLATFORM "Linux"
+#define BH_PLATFORM "Linux-SGX"
 
 /* NEED qsort */
 
@@ -66,11 +63,11 @@ extern void DEBUGME(void);
 
 #define INVALID_THREAD_ID 0xFFffFFff
 
-typedef pthread_t korp_tid;
-typedef pthread_mutex_t korp_mutex;
-typedef sem_t korp_sem;
-typedef pthread_cond_t korp_cond;
-typedef pthread_t korp_thread;
+typedef int korp_tid;
+typedef int korp_mutex;
+typedef int korp_sem;
+typedef int korp_cond;
+typedef int korp_thread;
 typedef void* (*thread_start_routine_t)(void*);
 
 #define wa_malloc bh_malloc

--- a/core/shared-lib/platform/linux-sgx/bh_platform_log.c
+++ b/core/shared-lib/platform/linux-sgx/bh_platform_log.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2019 Intel Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bh_platform.h"
+#include <stdio.h>
+
+void bh_log_emit(const char *fmt, va_list ap)
+{
+    vprintf(fmt, ap);
+    fflush(stdout);
+}
+
+int bh_fprintf(FILE *stream, const char *fmt, ...)
+{
+    va_list ap;
+    int ret;
+
+    va_start(ap, fmt);
+    ret = vfprintf(stream ? stream : stdout, fmt, ap);
+    va_end(ap);
+
+    return ret;
+}
+
+int bh_fflush(void *stream)
+{
+    return fflush(stream ? stream : stdout);
+}

--- a/core/shared-lib/platform/linux-sgx/bh_thread.c
+++ b/core/shared-lib/platform/linux-sgx/bh_thread.c
@@ -156,21 +156,6 @@ int _vm_cond_wait(korp_cond *cond, korp_mutex *mutex)
     //return BHT_ERROR;
 }
 
-static void msec_nsec_to_abstime(struct timespec *ts, int64 msec, int32 nsec)
-{
-    struct timeval tv;
-
-    // gettimeofday(&tv, NULL);
-
-    ts->tv_sec = tv.tv_sec + msec / 1000;
-    ts->tv_nsec = tv.tv_usec * 1000 + (msec % 1000) * 1000000 + nsec;
-
-    if (ts->tv_nsec >= 1000000000L) {
-        ts->tv_sec++;
-        ts->tv_nsec -= 1000000000L;
-    }
-}
-
 int _vm_cond_reltimedwait(korp_cond *cond, korp_mutex *mutex, int mills)
 {
     return BHT_OK;

--- a/core/shared-lib/platform/linux-sgx/bh_thread.c
+++ b/core/shared-lib/platform/linux-sgx/bh_thread.c
@@ -1,0 +1,205 @@
+/*
+ * Copyright (C) 2019 Intel Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bh_thread.h"
+#include "bh_assert.h"
+#include "bh_memory.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/time.h>
+
+int _vm_thread_sys_init()
+{
+    return 0;
+}
+
+void vm_thread_sys_destroy(void)
+{
+}
+
+int _vm_thread_create_with_prio(korp_tid *tid, thread_start_routine_t start,
+        void *arg, unsigned int stack_size, int prio)
+{
+    return BHT_ERROR;
+    // return BHT_OK;
+}
+
+int _vm_thread_create(korp_tid *tid, thread_start_routine_t start, void *arg,
+        unsigned int stack_size)
+{
+    return _vm_thread_create_with_prio(tid, start, arg, stack_size,
+                                       BH_THREAD_DEFAULT_PRIORITY);
+}
+
+korp_tid _vm_self_thread()
+{
+    return 0;
+}
+
+void vm_thread_exit(void * code)
+{
+}
+
+// storage for one thread
+static void *_tls_store = NULL;
+
+void *_vm_tls_get(unsigned idx)
+{
+    return _tls_store;
+}
+
+int _vm_tls_put(unsigned idx, void * tls)
+{
+    _tls_store = tls;
+    return BHT_OK;
+    //return BHT_ERROR;
+}
+
+int _vm_mutex_init(korp_mutex *mutex)
+{
+    return BHT_OK;
+    //return BHT_ERROR;
+}
+
+int _vm_recursive_mutex_init(korp_mutex *mutex)
+{
+    return BHT_OK;
+    //return BHT_ERROR;
+}
+
+int _vm_mutex_destroy(korp_mutex *mutex)
+{
+    return BHT_OK;
+    //return BHT_ERROR;
+}
+
+/* Returned error (EINVAL, EAGAIN and EDEADLK) from
+ locking the mutex indicates some logic error present in
+ the program somewhere.
+ Don't try to recover error for an existing unknown error.*/
+void vm_mutex_lock(korp_mutex *mutex)
+{
+}
+
+int vm_mutex_trylock(korp_mutex *mutex)
+{
+    return BHT_OK;
+    //return BHT_ERROR;
+}
+
+/* Returned error (EINVAL, EAGAIN and EPERM) from
+ unlocking the mutex indicates some logic error present
+ in the program somewhere.
+ Don't try to recover error for an existing unknown error.*/
+void vm_mutex_unlock(korp_mutex *mutex)
+{
+}
+
+int _vm_sem_init(korp_sem* sem, unsigned int c)
+{
+    return BHT_OK;
+    //return BHT_ERROR;
+}
+
+int _vm_sem_destroy(korp_sem *sem)
+{
+    return BHT_OK;
+    //return BHT_ERROR;
+}
+
+int _vm_sem_wait(korp_sem *sem)
+{
+    return BHT_OK;
+    //return BHT_ERROR;
+}
+
+int _vm_sem_reltimedwait(korp_sem *sem, int mills)
+{
+    return BHT_OK;
+    //return BHT_ERROR;
+}
+
+int _vm_sem_post(korp_sem *sem)
+{
+    return BHT_OK;
+    //return BHT_ERROR;
+}
+
+int _vm_cond_init(korp_cond *cond)
+{
+    return BHT_OK;
+    //return BHT_ERROR;
+}
+
+int _vm_cond_destroy(korp_cond *cond)
+{
+    return BHT_OK;
+    //return BHT_ERROR;
+}
+
+int _vm_cond_wait(korp_cond *cond, korp_mutex *mutex)
+{
+    return BHT_OK;
+    //return BHT_ERROR;
+}
+
+static void msec_nsec_to_abstime(struct timespec *ts, int64 msec, int32 nsec)
+{
+    struct timeval tv;
+
+    // gettimeofday(&tv, NULL);
+
+    ts->tv_sec = tv.tv_sec + msec / 1000;
+    ts->tv_nsec = tv.tv_usec * 1000 + (msec % 1000) * 1000000 + nsec;
+
+    if (ts->tv_nsec >= 1000000000L) {
+        ts->tv_sec++;
+        ts->tv_nsec -= 1000000000L;
+    }
+}
+
+int _vm_cond_reltimedwait(korp_cond *cond, korp_mutex *mutex, int mills)
+{
+    return BHT_OK;
+    //return BHT_ERROR;
+}
+
+int _vm_cond_signal(korp_cond *cond)
+{
+    return BHT_OK;
+    //return BHT_ERROR;
+}
+
+int _vm_cond_broadcast(korp_cond *cond)
+{
+    return BHT_OK;
+    //return BHT_ERROR;
+}
+
+int _vm_thread_cancel(korp_tid thread)
+{
+    return 0;
+}
+
+int _vm_thread_join(korp_tid thread, void **value_ptr, int mills)
+{
+    return 0;
+}
+
+int _vm_thread_detach(korp_tid thread)
+{
+    return 0;
+}

--- a/core/shared-lib/platform/linux-sgx/bh_time.c
+++ b/core/shared-lib/platform/linux-sgx/bh_time.c
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2019 Intel Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bh_time.h"
+
+#include <unistd.h>
+#include <stdio.h>
+#include <sys/timeb.h>
+#include <time.h>
+
+/*
+ * This function returns milliseconds per tick.
+ * @return milliseconds per tick.
+ */
+uint64 _bh_time_get_tick_millisecond()
+{
+    return sysconf(_SC_CLK_TCK);
+}
+
+/*
+ * This function returns milliseconds after boot.
+ * @return milliseconds after boot.
+ */
+uint64 _bh_time_get_boot_millisecond()
+{
+    struct timespec ts;
+    if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) {
+        return 0;
+    }
+
+    return ((uint64) ts.tv_sec) * 1000 + ts.tv_nsec / (1000 * 1000);
+}
+
+uint32 bh_get_tick_sec()
+{
+    return _bh_time_get_boot_millisecond() / 1000;
+}
+
+/*
+ * This function returns GMT time milliseconds since from 1970.1.1, AKA UNIX time.
+ * @return milliseconds since from 1970.1.1.
+ */
+uint64 _bh_time_get_millisecond_from_1970()
+{
+    struct timeb tp;
+    ftime(&tp);
+
+    return ((uint64) tp.time) * 1000 + tp.millitm
+            - (tp.dstflag == 0 ? 0 : 60 * 60 * 1000) + tp.timezone * 60 * 1000;
+}
+
+size_t _bh_time_strftime(char *s, size_t max, const char *format, int64 time)
+{
+    time_t time_sec = time / 1000;
+    struct timeb tp;
+    struct tm *ltp;
+
+    ftime(&tp);
+    time_sec -= tp.timezone * 60;
+
+    ltp = localtime(&time_sec);
+    if (ltp == NULL) {
+        return 0;
+    }
+    return strftime(s, max, format, ltp);
+}
+

--- a/core/shared-lib/platform/linux-sgx/shared_platform.cmake
+++ b/core/shared-lib/platform/linux-sgx/shared_platform.cmake
@@ -1,0 +1,24 @@
+# Copyright (C) 2019 Intel Corporation.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set (PLATFORM_SHARED_DIR ${CMAKE_CURRENT_LIST_DIR})
+
+include_directories(${PLATFORM_SHARED_DIR})
+include_directories(${PLATFORM_SHARED_DIR}/../include)
+
+
+file (GLOB_RECURSE source_all ${PLATFORM_SHARED_DIR}/*.c)
+
+set (PLATFORM_SHARED_SOURCE ${source_all})
+

--- a/core/shared-lib/platform/linux/bh_platform.c
+++ b/core/shared-lib/platform/linux/bh_platform.c
@@ -79,4 +79,3 @@ bh_read_file_to_buffer(const char *filename, int *ret_size)
     *ret_size = file_size;
     return buffer;
 }
-

--- a/core/shared-lib/platform/linux/bh_platform.h
+++ b/core/shared-lib/platform/linux/bh_platform.h
@@ -41,6 +41,8 @@
 extern "C" {
 #endif
 
+#define bh_printf printf
+
 typedef uint64_t uint64;
 typedef int64_t int64;
 

--- a/core/shared-lib/utils/bh_log.c
+++ b/core/shared-lib/utils/bh_log.c
@@ -20,6 +20,8 @@
  * @brief Implementation of Beihai's log system.
  */
 
+#if BEIHAI_ENABLE_LOG != 0
+
 #include "bh_assert.h"
 #include "bh_time.h"
 #include "bh_thread.h"
@@ -211,3 +213,4 @@ int bh_log_dcom_is_enabled(int component)
 
 #endif /* defined(BH_DEBUG) */
 
+#endif /* */


### PR DESCRIPTION
This is primarily for review/information only. 

This PR creates a new platform called linux-sgx that creates a version of the vmlib library that can be linked into an application that creates an iwasm interpreter inside an SGX enclave. Much of the code makes it possible to remove functions (like printf) that cannot be called inside SGX. Note that a definition for bh_printf must be including in the platform.h header file. I've only added this for Linux and Linux-SGX.