### PR TITLE
Add interpreter commands to get at interpreter specific data.

### DIFF
--- a/core/iwasm/runtime/include/wasm_export.h
+++ b/core/iwasm/runtime/include/wasm_export.h
@@ -255,6 +255,19 @@ void
 wasm_runtime_clear_exception(wasm_module_inst_t module_inst);
 
 /**
+ * Save data with the module instance
+ */
+bool
+wasm_runtime_set_instance_data(wasm_module_inst_t module_inst,
+                               void *thread_data);
+
+/**
+ * Retrieve saved instance data
+ */
+void*
+wasm_runtime_get_instance_data(wasm_module_inst_t module_inst);
+
+/**
  * Attach the current native thread to a WASM module instance.
  * A native thread cannot be attached simultaneously to two WASM module
  * instances. The WASM module instance will be attached to the native

--- a/core/iwasm/runtime/vmcore-wasm/wasm_runtime.c
+++ b/core/iwasm/runtime/vmcore-wasm/wasm_runtime.c
@@ -1134,6 +1134,20 @@ wasm_runtime_destroy_exec_env(WASMExecEnv *env)
 }
 
 bool
+wasm_runtime_set_instance_data(WASMModuleInstance *module_inst,
+                                     void *thread_data)
+{
+    module_inst->thread_data = thread_data;
+    return true;
+}
+
+void*
+wasm_runtime_get_instance_data(WASMModuleInstance *module_inst)
+{
+    return module_inst->thread_data;
+}
+
+bool
 wasm_runtime_attach_current_thread(WASMModuleInstance *module_inst,
                                    void *thread_data)
 {
@@ -1674,4 +1688,3 @@ wasm_runtime_invoke_native(void *func_ptr, WASMType *func_type,
 }
 
 #endif /* end of !defined(__x86_64__) && !defined(__amd_64__) */
-


### PR DESCRIPTION
This is just a proposal for a more general API for getting/setting interpreter specific data in the thread data section. This assumes that the application will clean up any allocated memory.

Signed-off-by: Mic Bowman <mic.bowman@intel.com>