### PR TITLE
Error related to invokeNative_em64.s

### DIFF
--- a/core/iwasm/runtime/vmcore-wasm/invokeNative_em64.s
+++ b/core/iwasm/runtime/vmcore-wasm/invokeNative_em64.s
@@ -15,9 +15,9 @@
  */
     .text
     .align 2
-.globl invokeNative
-    .type    invokeNative, @function
-invokeNative:
+.globl _invokeNative
+    //.type    invokeNative, @function
+_invokeNative:
     /*  rdi - function ptr */
     /*  rsi - argv */
     /*  rdx - n_stacks */


### PR DESCRIPTION
There is a compiling error on OSX 10.15 which is supposed to relate to the Mach-O x86-64 ABI for OSX. 
Here is the error message:
```
invokeNative_em64.s:19:5: error: error: unknown directive
    .type invokeNative, @function
```
when using clang from Xcode:
```
Apple clang version 11.0.0 (clang-1100.0.33.8)
Target: x86_64-apple-darwin19.0.0
Thread model: posix
```
The new modification of this file solves the compiling issue. The iwasm tests well after the modification